### PR TITLE
Initialize project structure with backend and frontend basics

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,7 @@
+const app = require('./src/app');
+
+const PORT = process.env.PORT || 5000;
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const morgan = require('morgan');
+const helmet = require('helmet');
+const cors = require('cors');
+const { connectDB } = require('./db/connection');
+const { MONGO_URI } = require('./utils/constants');
+
+const app = express();
+
+app.use(helmet());
+app.use(cors());
+app.use(morgan('dev'));
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+async function init() {
+  await connectDB(MONGO_URI);
+}
+
+init().catch(err => {
+  console.error('Failed to connect to DB', err);
+  process.exit(1);
+});
+
+// TODO: Mount routes here
+
+module.exports = app;

--- a/backend/src/db/connection.js
+++ b/backend/src/db/connection.js
@@ -1,0 +1,28 @@
+const mongoose = require('mongoose');
+const { MongoClient, GridFSBucket } = require('mongodb');
+const config = require('../utils/constants');
+
+const connection = {};
+
+async function connectDB(uri) {
+  if (connection.isConnected) return connection.client;
+
+  await mongoose.connect(uri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+
+  const client = new MongoClient(uri, { useUnifiedTopology: true });
+  await client.connect();
+
+  const db = client.db();
+  const bucket = new GridFSBucket(db, { bucketName: 'uploads' });
+
+  connection.client = client;
+  connection.bucket = bucket;
+  connection.isConnected = true;
+
+  return client;
+}
+
+module.exports = { connectDB, connection };

--- a/backend/src/models/Company.js
+++ b/backend/src/models/Company.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const CompanySchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    domain: { type: String },
+    tier: { type: String },
+    healthScore: { type: Number, default: 0 },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Company', CompanySchema);

--- a/backend/src/models/Contact.js
+++ b/backend/src/models/Contact.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const ContactSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+    phone: { type: String },
+    company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company' },
+    status: { type: String, enum: ['active', 'blocked', 'deleted'], default: 'active' },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Contact', ContactSchema);

--- a/backend/src/models/Group.js
+++ b/backend/src/models/Group.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const GroupSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    description: { type: String },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Group', GroupSchema);

--- a/backend/src/models/SLA.js
+++ b/backend/src/models/SLA.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const SLASchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    responseTime: { type: Number, required: true }, // in hours
+    resolutionTime: { type: Number, required: true }, // in hours
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('SLA', SLASchema);

--- a/backend/src/models/Ticket.js
+++ b/backend/src/models/Ticket.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const TicketSchema = new mongoose.Schema(
+  {
+    subject: { type: String, required: true },
+    description: { type: String },
+    status: { type: String, default: 'open' },
+    priority: { type: String, enum: ['low', 'medium', 'high'], default: 'low' },
+    contact: { type: mongoose.Schema.Types.ObjectId, ref: 'Contact' },
+    company: { type: mongoose.Schema.Types.ObjectId, ref: 'Company' },
+    agent: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    group: { type: mongoose.Schema.Types.ObjectId, ref: 'Group' },
+    tags: [String],
+    reference: { type: String },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Ticket', TicketSchema);

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const UserSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+    password: { type: String, required: true },
+    role: { type: String, enum: ['admin', 'staff', 'user'], default: 'user' },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('User', UserSchema);

--- a/backend/src/utils/constants.js
+++ b/backend/src/utils/constants.js
@@ -1,0 +1,3 @@
+module.exports = {
+  MONGO_URI: process.env.MONGO_URI || 'mongodb://localhost:27017/ticketing',
+};

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function App() {
+  return (
+    <div className="container mt-5">
+      <h1>Ticketing Tool</h1>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import 'bootstrap/dist/css/bootstrap.min.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold backend and frontend directory layout
- implement MongoDB connection and GridFS bucket setup
- create initial Express app and server entry
- add basic Mongoose models for core entities
- create minimal React frontend with Vite configuration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684d96fe72e48325a825f4c003fd670a