### PR TITLE
Add GridFS Mongo connection

### DIFF
--- a/backend/src/db/connection.js
+++ b/backend/src/db/connection.js
@@ -1,12 +1,22 @@
 const mongoose = require('mongoose');
+const Grid = require('gridfs-stream');
+
+let gridfsBucket;
 
 async function connect() {
   const uri = process.env.MONGO_URI;
   if (!uri) {
     throw new Error('MONGO_URI is not defined');
   }
+
   await mongoose.connect(uri);
+  Grid.mongo = mongoose.mongo;
+  gridfsBucket = Grid(mongoose.connection.db, mongoose.mongo);
   return mongoose.connection;
 }
 
-module.exports = connect;
+module.exports = {
+  connect,
+  connection: mongoose.connection,
+  gridfsBucket,
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
-    "mongoose": "^7.2.2"
+    "mongoose": "^7.2.2",
+    "gridfs-stream": "^1.1.1"
   }
 }


### PR DESCRIPTION
## Summary
- connect to MongoDB in `backend/src/db/connection.js`
- add GridFS stream initialization and export connection & bucket
- include `gridfs-stream` dependency in `package.json`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684d99a4abf88325b44488f88340e1ae