### PR TITLE
Add basic Socket.IO server with Redis adapter

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const http = require('http');
 const app = require('./src/app');
 const connectDb = require('./src/db/connection');
+const { initSocket } = require('./src/sockets');
 
 const port = process.env.PORT || 3000;
 
@@ -9,6 +10,7 @@ async function start() {
   try {
     await connectDb();
     const server = http.createServer(app);
+    initSocket(server);
     server.listen(port, () => {
       console.log(`Server running on port ${port}`);
     });

--- a/backend/src/sockets/index.js
+++ b/backend/src/sockets/index.js
@@ -1,0 +1,38 @@
+// Basic Socket.IO server setup
+const { Server } = require('socket.io');
+const { createAdapter } = require('@socket.io/redis-adapter');
+const { createClient } = require('redis');
+
+function initSocket(server) {
+  const io = new Server(server, {
+    cors: {
+      origin: '*',
+    },
+  });
+
+  io.on('connection', (socket) => {
+    console.log(`Socket connected: ${socket.id}`);
+    socket.on('disconnect', () => {
+      console.log(`Socket disconnected: ${socket.id}`);
+    });
+  });
+
+  const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+  const pubClient = createClient({ url: redisUrl });
+  const subClient = pubClient.duplicate();
+
+  Promise.all([pubClient.connect(), subClient.connect()])
+    .then(() => {
+      io.adapter(createAdapter(pubClient, subClient));
+      console.log('Socket.IO Redis adapter connected');
+    })
+    .catch((err) => {
+      console.error('Failed to connect Redis adapter:', err);
+    });
+
+  return io;
+}
+
+module.exports = {
+  initSocket,
+};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "mongoose": "^7.2.2",
-    "gridfs-stream": "^1.1.1"
+    "gridfs-stream": "^1.1.1",
+    "socket.io": "^4.7.2",
+    "redis": "^4.6.7",
+    "@socket.io/redis-adapter": "^8.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Socket.IO server configuration
- hook the socket server into server.js
- include Redis adapter setup with connection logs
- add socket.io and redis packages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_b_684d9c2cced083258c1fe63844fdfc49