### PR TITLE
Add ticket queue with BullMQ

### DIFF
--- a/backend/src/jobs/ticketQueue.js
+++ b/backend/src/jobs/ticketQueue.js
@@ -1,0 +1,19 @@
+const { Queue, Worker } = require('bullmq');
+const IORedis = require('ioredis');
+
+const connection = new IORedis(process.env.REDIS_URL || 'redis://localhost:6379');
+
+const ticketQueue = new Queue('ticketQueue', { connection });
+
+new Worker(
+  'ticketQueue',
+  async (job) => {
+    console.log(`Processing ticket job ${job.id}`, job.data);
+    // Placeholder for ticket creation or logging logic
+  },
+  { connection }
+).on('failed', (job, err) => {
+  console.error(`Job ${job.id} failed`, err);
+});
+
+module.exports = ticketQueue;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "gridfs-stream": "^1.1.1",
     "socket.io": "^4.7.2",
     "redis": "^4.6.7",
-    "@socket.io/redis-adapter": "^8.2.0"
+    "@socket.io/redis-adapter": "^8.2.0",
+    "bullmq": "^4.7.1",
+    "ioredis": "^5.3.2"
   }
 }


### PR DESCRIPTION
## Summary
- integrate BullMQ and ioredis
- implement a simple ticket queue processor

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d9cc741f0832597f1923949d1730d