### PR TITLE
Add utility modules and example controller

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,20 +1,18 @@
 const express = require('express');
 const cors = require('cors');
 
+const pingRoutes = require('./routes/pingRoutes');
+const errorHandler = require('./middleware/errorHandler');
+
 const app = express();
 
 app.use(cors());
 app.use(express.json());
 
-// Placeholder route
-app.get('/api/ping', (req, res) => {
-  res.json({ message: 'pong' });
-});
+// Routes
+app.use('/api', pingRoutes);
 
-// Error handling middleware placeholder
-app.use((err, req, res, next) => {
-  console.error(err);
-  res.status(500).json({ error: 'Internal Server Error' });
-});
+// Global error handler
+app.use(errorHandler);
 
 module.exports = app;

--- a/backend/src/controllers/pingController.js
+++ b/backend/src/controllers/pingController.js
@@ -1,0 +1,10 @@
+const asyncHandler = require('../utils/asyncHandler');
+const apiResponse = require('../utils/apiResponse');
+const apiError = require('../utils/apiError');
+
+exports.ping = asyncHandler(async (req, res, next) => {
+  // Example of using the utilities; no error condition here
+  return res
+    .status(200)
+    .json(new apiResponse(200, { message: 'pong' }, 'Ping successful'));
+});

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,7 +1,17 @@
-// Global error handler middleware placeholder
+const apiError = require('../utils/apiError');
+const apiResponse = require('../utils/apiResponse');
+
 function errorHandler(err, req, res, next) {
-  // TODO: handle errors globally
-  res.status(500).json({ error: 'Internal Server Error' });
+  if (err instanceof apiError) {
+    return res
+      .status(err.statusCode)
+      .json(new apiResponse(err.statusCode, err.errors, err.message));
+  }
+
+  console.error(err);
+  return res
+    .status(500)
+    .json(new apiResponse(500, null, 'Internal Server Error'));
 }
 
 module.exports = errorHandler;

--- a/backend/src/routes/pingRoutes.js
+++ b/backend/src/routes/pingRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { ping } = require('../controllers/pingController');
+
+const router = express.Router();
+
+router.get('/ping', ping);
+
+module.exports = router;

--- a/backend/src/utils/apiError.js
+++ b/backend/src/utils/apiError.js
@@ -1,0 +1,11 @@
+class apiError extends Error {
+  constructor(statusCode, message = 'error', errors = null) {
+    super(message);
+    this.statusCode = statusCode;
+    if (errors) {
+      this.errors = errors;
+    }
+  }
+}
+
+module.exports = apiError;

--- a/backend/src/utils/apiResponse.js
+++ b/backend/src/utils/apiResponse.js
@@ -1,0 +1,9 @@
+class apiResponse {
+  constructor(statusCode, data = null, message = 'success') {
+    this.statusCode = statusCode;
+    this.data = data;
+    this.message = message;
+  }
+}
+
+module.exports = apiResponse;

--- a/backend/src/utils/asyncHandler.js
+++ b/backend/src/utils/asyncHandler.js
@@ -1,0 +1,5 @@
+const asyncHandler = (fn) => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};
+
+module.exports = asyncHandler;


### PR DESCRIPTION
## Summary
- add apiError, apiResponse and asyncHandler utilities
- update global error handler to use standardized error responses
- refactor `app.js` to use new ping route and middleware
- provide example ping controller using utilities

## Testing
- `npm start` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_684da114620c832589f53fc5d6fefd45