### PR TITLE
Implement modular user registration

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 
 const pingRoutes = require('./routes/pingRoutes');
+const userRoutes = require('./routes/userRoutes');
 const errorHandler = require('./middleware/errorHandler');
 
 const app = express();
@@ -10,7 +11,8 @@ app.use(cors());
 app.use(express.json());
 
 // Routes
-app.use('/api', pingRoutes);
+app.use('/api/v2', pingRoutes);
+app.use('/api/v2/register', userRoutes);
 
 // Global error handler
 app.use(errorHandler);

--- a/backend/src/controllers/user/registerController.js
+++ b/backend/src/controllers/user/registerController.js
@@ -1,0 +1,124 @@
+const User = require('../../models/User');
+const apiResponse = require('../../utils/apiResponse');
+
+exports.registerAdmin = async (req, res, next) => {
+  try {
+    const { firstName, lastName, email, company, phone } = req.body;
+    const normalizedEmail = email.toLowerCase();
+
+    const existing = await User.aggregate([
+      { $match: { email: normalizedEmail } },
+      { $project: { _id: 1 } },
+    ]);
+
+    if (existing.length > 0) {
+      return res
+        .status(400)
+        .json(new apiResponse(400, null, 'Email already exists'));
+    }
+
+    const newUser = new User({
+      role: 'admin',
+      firstName,
+      lastName,
+      company,
+      phone,
+      email: normalizedEmail,
+    });
+
+    await newUser.save();
+    return res
+      .status(201)
+      .json(new apiResponse(201, newUser, 'Admin registered successfully'));
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.registerContact = async (req, res, next) => {
+  try {
+    const {
+      fullName,
+      email,
+      phone,
+      company,
+      address,
+      timezone,
+      tags,
+      language,
+    } = req.body;
+    const normalizedEmail = email.toLowerCase();
+
+    const existing = await User.aggregate([
+      { $match: { email: normalizedEmail } },
+      { $project: { _id: 1 } },
+    ]);
+
+    if (existing.length > 0) {
+      return res
+        .status(400)
+        .json(new apiResponse(400, null, 'Email already exists'));
+    }
+
+    const newUser = new User({
+      role: 'contact',
+      fullName,
+      email: normalizedEmail,
+      phone,
+      company,
+      address,
+      timezone,
+      tags,
+      language,
+    });
+
+    await newUser.save();
+    return res
+      .status(201)
+      .json(new apiResponse(201, newUser, 'Contact registered successfully'));
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.registerAgent = async (req, res, next) => {
+  try {
+    const {
+      email,
+      agentType,
+      availability,
+      timezone,
+      signature,
+      groups,
+    } = req.body;
+    const normalizedEmail = email.toLowerCase();
+
+    const existing = await User.aggregate([
+      { $match: { email: normalizedEmail } },
+      { $project: { _id: 1 } },
+    ]);
+
+    if (existing.length > 0) {
+      return res
+        .status(400)
+        .json(new apiResponse(400, null, 'Email already exists'));
+    }
+
+    const newUser = new User({
+      role: 'agent',
+      email: normalizedEmail,
+      agentType,
+      availability,
+      timezone,
+      signature,
+      groups,
+    });
+
+    await newUser.save();
+    return res
+      .status(201)
+      .json(new apiResponse(201, newUser, 'Agent registered successfully'));
+  } catch (err) {
+    next(err);
+  }
+};

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -2,8 +2,38 @@ const mongoose = require('mongoose');
 
 const UserSchema = new mongoose.Schema(
   {
-    name: { type: String, required: true },
-    email: { type: String, required: true }
+    role: {
+      type: String,
+      enum: ['admin', 'contact', 'agent'],
+      required: true,
+    },
+    // common fields
+    email: { type: String, required: true },
+
+    // Admin specific
+    firstName: String,
+    lastName: String,
+    company: String,
+    phone: String,
+
+    // Contact specific
+    fullName: String,
+    address: String,
+    timezone: String,
+    tags: [String],
+    language: String,
+
+    // Agent specific
+    agentType: {
+      type: String,
+      enum: ['collaborator', 'support'],
+    },
+    availability: {
+      type: String,
+      enum: ['full-time', 'occasional'],
+    },
+    signature: String,
+    groups: [String],
   },
   { timestamps: true }
 );

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const {
+  registerAdmin,
+  registerContact,
+  registerAgent,
+} = require('../controllers/user/registerController');
+
+const router = express.Router();
+
+router.post('/admin', registerAdmin);
+router.post('/contact', registerContact);
+router.post('/agent', registerAgent);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- expand the `User` model to cover admin, contact, and agent roles
- add registration controllers for each user type
- add routes for registration endpoints and mount in app
- update base API path to `/api/v2`

## Testing
- `npm test --silent` *(no output)*
- `npm start --silent` *(fails: Cannot find module 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_b_684e741388e88325b4ab0bd8940101b9