### PR TITLE
Implement modular user registration

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const http = require('http');
 const app = require('./src/app');
 const connectDb = require('./src/db/connection');
+const { connectRedis } = require('./src/db/redis');
 const { initSocket } = require('./src/sockets');
 
 const port = process.env.PORT || 3000;
@@ -9,6 +10,7 @@ const port = process.env.PORT || 3000;
 async function start() {
   try {
     await connectDb();
+    await connectRedis();
     const server = http.createServer(app);
     initSocket(server);
     server.listen(port, () => {

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 
 const pingRoutes = require('./routes/pingRoutes');
+const userRoutes = require('./routes/userRoutes');
 const errorHandler = require('./middleware/errorHandler');
 
 const app = express();
@@ -10,7 +11,8 @@ app.use(cors());
 app.use(express.json());
 
 // Routes
-app.use('/api', pingRoutes);
+app.use('/api/v2', pingRoutes);
+app.use('/api/v2/register', userRoutes);
 
 // Global error handler
 app.use(errorHandler);

--- a/backend/src/controllers/pingController.js
+++ b/backend/src/controllers/pingController.js
@@ -2,9 +2,13 @@ const asyncHandler = require('../utils/asyncHandler');
 const apiResponse = require('../utils/apiResponse');
 const apiError = require('../utils/apiError');
 
-exports.ping = asyncHandler(async (req, res, next) => {
+const ping = asyncHandler(async (req, res, next) => {
   // Example of using the utilities; no error condition here
   return res
     .status(200)
     .json(new apiResponse(200, { message: 'pong' }, 'Ping successful'));
 });
+
+module.exports = {
+  ping,
+};

--- a/backend/src/controllers/user/registerController.js
+++ b/backend/src/controllers/user/registerController.js
@@ -1,0 +1,147 @@
+const User = require('../../models/User');
+const asyncHandler = require('../../utils/asyncHandler');
+const apiResponse = require('../../utils/apiResponse');
+const apiError = require('../../utils/apiError');
+const { redisClient } = require('../../db/redis');
+const { createToken } = require('../../services/tokenService');
+
+const registerAdmin = asyncHandler(async (req, res) => {
+  const { firstName, lastName, email, company, phone } = req.body;
+  const normalizedEmail = email.toLowerCase();
+  const cacheKey = `user:${normalizedEmail}`;
+
+  if (await redisClient.get(cacheKey)) {
+    throw new apiError(400, 'Email already exists');
+  }
+
+  const existing = await User.aggregate([
+    { $match: { email: normalizedEmail } },
+    { $project: { _id: 1 } },
+  ]);
+
+  if (existing.length > 0) {
+    await redisClient.set(cacheKey, '1');
+    throw new apiError(400, 'Email already exists');
+  }
+
+  const newUser = new User({
+    role: 'admin',
+    firstName,
+    lastName,
+    company,
+    phone,
+    email: normalizedEmail,
+  });
+
+  await newUser.save();
+  await redisClient.set(cacheKey, '1');
+  const token = createToken({ id: newUser._id, role: newUser.role });
+
+  return res
+    .status(201)
+    .json(new apiResponse(201, { user: newUser, token }, 'Admin registered successfully'));
+});
+
+const registerContact = asyncHandler(async (req, res) => {
+  const {
+    fullName,
+    email,
+    phone,
+    company,
+    address,
+    timezone,
+    tags,
+    language,
+  } = req.body;
+  const normalizedEmail = email.toLowerCase();
+  const cacheKey = `user:${normalizedEmail}`;
+
+  if (await redisClient.get(cacheKey)) {
+    throw new apiError(400, 'Email already exists');
+  }
+
+  const existing = await User.aggregate([
+    { $match: { email: normalizedEmail } },
+    { $project: { _id: 1 } },
+  ]);
+
+  if (existing.length > 0) {
+    await redisClient.set(cacheKey, '1');
+    throw new apiError(400, 'Email already exists');
+  }
+
+  const newUser = new User({
+    role: 'contact',
+    fullName,
+    email: normalizedEmail,
+    phone,
+    company,
+    address,
+    timezone,
+    tags,
+    language,
+  });
+
+  await newUser.save();
+  await redisClient.set(cacheKey, '1');
+
+  const token = createToken({ id: newUser._id, role: newUser.role });
+
+  return res
+    .status(201)
+    .json(new apiResponse(201, { user: newUser, token }, 'Contact registered successfully'));
+});
+
+const registerAgent = asyncHandler(async (req, res) => {
+  const {
+    fullName,
+    email,
+    agentType,
+    availability,
+    timezone,
+    signature,
+    groups,
+  } = req.body;
+  const normalizedEmail = email.toLowerCase();
+  const cacheKey = `user:${normalizedEmail}`;
+
+  if (await redisClient.get(cacheKey)) {
+    throw new apiError(400, 'Email already exists');
+  }
+
+  const existing = await User.aggregate([
+    { $match: { email: normalizedEmail } },
+    { $project: { _id: 1 } },
+  ]);
+
+  if (existing.length > 0) {
+    await redisClient.set(cacheKey, '1');
+    throw new apiError(400, 'Email already exists');
+  }
+
+  const newUser = new User({
+    role: 'agent',
+    fullName,
+    email: normalizedEmail,
+    agentType,
+    availability,
+    timezone,
+    signature,
+    groups,
+  });
+
+  await newUser.save();
+  await redisClient.set(cacheKey, '1');
+
+  const token = createToken({ id: newUser._id, role: newUser.role });
+
+  return res
+    .status(201)
+    .json(new apiResponse(201, { user: newUser, token }, 'Agent registered successfully'));
+});
+
+module.exports = {
+  registerAdmin,
+  registerContact,
+  registerAgent,
+};

--- a/backend/src/db/redis.js
+++ b/backend/src/db/redis.js
@@ -1,0 +1,19 @@
+const { createClient } = require('redis');
+
+const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+const redisClient = createClient({ url: redisUrl });
+
+redisClient.on('error', (err) => {
+  console.error('Redis Client Error', err);
+});
+
+async function connectRedis() {
+  if (!redisClient.isOpen) {
+    await redisClient.connect();
+  }
+}
+
+module.exports = {
+  redisClient,
+  connectRedis,
+};

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,6 +1,17 @@
-// JWT verification middleware placeholder
+const { verifyToken } = require('../services/tokenService');
+const apiError = require('../utils/apiError');
+
 function auth(req, res, next) {
-  // TODO: verify JWT token
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return next(new apiError(401, 'No token provided'));
+  }
+  const token = authHeader.split(' ')[1];
+  const decoded = verifyToken(token);
+  if (!decoded) {
+    return next(new apiError(401, 'Invalid token'));
+  }
+  req.user = decoded;
   next();
 }
 

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -2,8 +2,44 @@ const mongoose = require('mongoose');
 
 const UserSchema = new mongoose.Schema(
   {
-    name: { type: String, required: true },
-    email: { type: String, required: true }
+    role: {
+      type: String,
+      enum: ['admin', 'contact', 'agent'],
+      required: true,
+    },
+    // common fields
+    email: { type: String, required: true },
+
+    // Admin specific
+    firstName: String,
+    lastName: String,
+    company: String,
+    phone: String,
+
+    // Contact/Agent specific
+    fullName: {
+      type: String,
+      required: function () {
+        return this.role === 'agent' || this.role === 'contact';
+      },
+    },
+    address: String,
+    timezone: String,
+    tags: [String],
+    language: String,
+
+    // Agent specific
+    // fullName and email fields are also applicable to agents
+    agentType: {
+      type: String,
+      enum: ['collaborator', 'support'],
+    },
+    availability: {
+      type: String,
+      enum: ['full-time', 'occasional'],
+    },
+    signature: String,
+    groups: [String],
   },
   { timestamps: true }
 );

--- a/backend/src/routes/userRoutes.js
+++ b/backend/src/routes/userRoutes.js
@@ -1,0 +1,14 @@
+const express = require('express');
+const {
+  registerAdmin,
+  registerContact,
+  registerAgent,
+} = require('../controllers/user/registerController');
+
+const router = express.Router();
+
+router.post('/admin', registerAdmin);
+router.post('/contact', registerContact);
+router.post('/agent', registerAgent);
+
+module.exports = router;

--- a/backend/src/services/tokenService.js
+++ b/backend/src/services/tokenService.js
@@ -1,10 +1,17 @@
-// JWT creation and verification service placeholder
-function createToken(payload) {
-  // TODO: create JWT
+const jwt = require('jsonwebtoken');
+
+const JWT_SECRET = process.env.JWT_SECRET || 'change_this_secret';
+
+function createToken(payload, expiresIn = '1h') {
+  return jwt.sign(payload, JWT_SECRET, { expiresIn });
 }
 
 function verifyToken(token) {
-  // TODO: verify JWT
+  try {
+    return jwt.verify(token, JWT_SECRET);
+  } catch (err) {
+    return null;
+  }
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "redis": "^4.6.7",
     "@socket.io/redis-adapter": "^8.2.0",
     "bullmq": "^4.7.1",
-    "ioredis": "^5.3.2"
+    "ioredis": "^5.3.2",
+    "jsonwebtoken": "^9.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- expand the `User` model to cover admin, contact, and agent roles
- add registration controllers for each user type
- add routes for registration endpoints and mount in app
- update base API path to `/api/v2`
- include `fullName` when registering agents
- refactor controllers with async utilities
- cache email checks in Redis and connect client at startup
- make controller functions constants exported at bottom
- **require `fullName` for contacts and agents**
- add JWT token utilities and middleware
- return a token when registering

## Testing
- `npm test --silent`
- `npm start --silent` *(fails: Cannot find module 'dotenv')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_b_684e741388e88325b4ab0bd8940101b9