### PR TITLE
Add redux user store on registration

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,10 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.0",
-    "react-router-dom": "^6.14.1"
+    "react-router-dom": "^6.14.1",
+    "axios": "^1.4.0",
+    "bootstrap-icons": "^1.10.5",
+    "react-bootstrap": "^2.7.4"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,12 +1,37 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Navbar from './components/Navbar';
+import Sidebar from './components/Sidebar/Sidebar';
+import Register from './components/Auth/Register';
+import Dashboard from './pages/Dashboard';
+import Tickets from './pages/Tickets';
+import Contacts from './pages/Contacts';
+import Companies from './pages/Companies';
+import Solutions from './pages/Solutions';
+import Forums from './pages/Forums';
+import Analytics from './pages/Analytics';
+import AdminSettings from './pages/AdminSettings';
+import Login from './pages/Login';
 
 const App = () => {
   return (
     <Router>
-      <Routes>
-        {/* Define routes here */}
-      </Routes>
+      <Navbar />
+      <Sidebar />
+      <div className="container-fluid">
+        <Routes>
+          <Route path="/register" element={<Register />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/tickets" element={<Tickets />} />
+          <Route path="/users/contacts" element={<Contacts />} />
+          <Route path="/users/companies" element={<Companies />} />
+          <Route path="/solutions" element={<Solutions />} />
+          <Route path="/forums" element={<Forums />} />
+          <Route path="/analytics" element={<Analytics />} />
+          <Route path="/admin" element={<AdminSettings />} />
+        </Routes>
+      </div>
     </Router>
   );
 };

--- a/frontend/src/components/Auth/Register.jsx
+++ b/frontend/src/components/Auth/Register.jsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { registerAdmin } from '../../services/authService';
+import { setUser } from '../../store/authSlice';
+
+const Register = () => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const [formData, setFormData] = useState({
+    firstName: '',
+    lastName: '',
+    workEmail: '',
+    company: '',
+    phone: '',
+  });
+  const [error, setError] = useState(null);
+  const { firstName, lastName, workEmail, company, phone } = formData;
+
+  const onChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const user = await registerAdmin({
+        firstName,
+        lastName,
+        email: workEmail,
+        company,
+        phone,
+      });
+      dispatch(setUser(user));
+      navigate('/login');
+    } catch (err) {
+      setError(err.response?.data?.message || 'Registration failed');
+    }
+  };
+
+  return (
+    <div className="container mt-5" style={{ maxWidth: '500px' }}>
+      <h2 className="mb-4">Admin Registration</h2>
+      {error && <div className="alert alert-danger">{error}</div>}
+      <form onSubmit={onSubmit}>
+        <div className="mb-3">
+          <label className="form-label">First Name</label>
+          <input
+            type="text"
+            className="form-control"
+            name="firstName"
+            value={firstName}
+            onChange={onChange}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Last Name</label>
+          <input
+            type="text"
+            className="form-control"
+            name="lastName"
+            value={lastName}
+            onChange={onChange}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Work Email</label>
+          <input
+            type="email"
+            className="form-control"
+            name="workEmail"
+            value={workEmail}
+            onChange={onChange}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Company</label>
+          <input
+            type="text"
+            className="form-control"
+            name="company"
+            value={company}
+            onChange={onChange}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Phone (optional)</label>
+          <input
+            type="text"
+            className="form-control"
+            name="phone"
+            value={phone}
+            onChange={onChange}
+          />
+        </div>
+        <button type="submit" className="btn btn-primary w-100">
+          Register
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Register;

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { logout } from '../store/authSlice';
+import { Link } from 'react-router-dom';
+
+const Navbar = () => {
+  const user = useSelector((state) => state.auth.user);
+  const dispatch = useDispatch();
+
+  const handleLogout = () => {
+    dispatch(logout());
+  };
+
+  return (
+    <nav className="navbar navbar-light bg-light px-3">
+      <Link className="navbar-brand" to="/">
+        Ticketing Tool
+      </Link>
+      {user && (
+        <button className="btn btn-outline-secondary" onClick={handleLogout}>
+          Logout
+        </button>
+      )}
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/frontend/src/components/Sidebar/Sidebar.jsx
+++ b/frontend/src/components/Sidebar/Sidebar.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Offcanvas } from 'react-bootstrap';
+import SidebarItem from './SidebarItem';
+import SubMenu from './SubMenu';
+
+const Sidebar = () => {
+  const [show, setShow] = useState(false);
+  const user = useSelector((state) => state.auth.user);
+
+  if (!user || (user.role !== 'admin' && user.role !== 'agent')) {
+    return null;
+  }
+
+  const toggle = () => setShow(!show);
+
+  return (
+    <>
+      <button className="btn btn-primary m-2" onClick={toggle}>
+        <i className="bi bi-list"></i>
+      </button>
+      <Offcanvas show={show} onHide={toggle} backdrop={false} className="bg-light" placement="start">
+        <Offcanvas.Header closeButton>
+          <Offcanvas.Title>Menu</Offcanvas.Title>
+        </Offcanvas.Header>
+        <Offcanvas.Body className="p-0">
+          <ul className="nav flex-column">
+            <SidebarItem to="/dashboard" icon="speedometer2" label="Dashboard" onClick={toggle} />
+            <SidebarItem to="/tickets" icon="ticket-perforated" label="Tickets" onClick={toggle} />
+            <SubMenu label="User" icon="people">
+              <SidebarItem to="/users/contacts" icon="person" label="Contacts" onClick={toggle} />
+              <SidebarItem to="/users/companies" icon="building" label="Companies" onClick={toggle} />
+            </SubMenu>
+            <SidebarItem to="/solutions" icon="journal" label="Solutions" onClick={toggle} />
+            <SidebarItem to="/forums" icon="chat" label="Forums" onClick={toggle} />
+            <SidebarItem to="/analytics" icon="bar-chart" label="Analytics" onClick={toggle} />
+            <SidebarItem to="/admin" icon="gear" label="Admin" onClick={toggle} />
+          </ul>
+        </Offcanvas.Body>
+      </Offcanvas>
+    </>
+  );
+};
+
+export default Sidebar;

--- a/frontend/src/components/Sidebar/SidebarItem.jsx
+++ b/frontend/src/components/Sidebar/SidebarItem.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+const SidebarItem = ({ to, icon, label, onClick }) => (
+  <li className="nav-item" onClick={onClick}>
+    <NavLink className="nav-link d-flex align-items-center" to={to}>
+      <i className={`bi bi-${icon} me-2`}></i>
+      <span>{label}</span>
+    </NavLink>
+  </li>
+);
+
+export default SidebarItem;

--- a/frontend/src/components/Sidebar/SubMenu.jsx
+++ b/frontend/src/components/Sidebar/SubMenu.jsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { Collapse } from 'react-bootstrap';
+
+const SubMenu = ({ label, icon, children }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <li className="nav-item" onClick={() => setOpen(!open)}>
+        <span className="nav-link d-flex align-items-center" role="button">
+          <i className={`bi bi-${icon} me-2`}></i>
+          <span>{label}</span>
+          <i className={`bi bi-chevron-${open ? 'up' : 'down'} ms-auto`}></i>
+        </span>
+      </li>
+      <Collapse in={open}>
+        <ul className="btn-toggle-nav list-unstyled fw-normal pb-1 small ms-4">
+          {children}
+        </ul>
+      </Collapse>
+    </>
+  );
+};
+
+export default SubMenu;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { Provider } from 'react-redux';
 import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
 import App from './App';
 import store from './store';
 

--- a/frontend/src/pages/AdminSettings.jsx
+++ b/frontend/src/pages/AdminSettings.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const AdminSettings = () => <div className="p-4">AdminSettings</div>;
+
+export default AdminSettings;

--- a/frontend/src/pages/Analytics.jsx
+++ b/frontend/src/pages/Analytics.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Analytics = () => <div className="p-4">Analytics</div>;
+
+export default Analytics;

--- a/frontend/src/pages/Companies.jsx
+++ b/frontend/src/pages/Companies.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Companies = () => <div className="p-4">Companies</div>;
+
+export default Companies;

--- a/frontend/src/pages/Contacts.jsx
+++ b/frontend/src/pages/Contacts.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Contacts = () => <div className="p-4">Contacts</div>;
+
+export default Contacts;

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Dashboard = () => <div className="p-4">Dashboard</div>;
+
+export default Dashboard;

--- a/frontend/src/pages/Forums.jsx
+++ b/frontend/src/pages/Forums.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Forums = () => <div className="p-4">Forums</div>;
+
+export default Forums;

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Login = () => <div className="p-4">Login</div>;
+
+export default Login;

--- a/frontend/src/pages/Solutions.jsx
+++ b/frontend/src/pages/Solutions.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Solutions = () => <div className="p-4">Solutions</div>;
+
+export default Solutions;

--- a/frontend/src/pages/Tickets.jsx
+++ b/frontend/src/pages/Tickets.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Tickets = () => <div className="p-4">Tickets</div>;
+
+export default Tickets;

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+const API_URL = '/api/register/';
+
+export const registerAdmin = async (data) => {
+  const response = await axios.post(`${API_URL}admin`, data);
+  return response.data;
+};
+
+export default { registerAdmin };

--- a/frontend/src/store/authSlice.js
+++ b/frontend/src/store/authSlice.js
@@ -1,0 +1,19 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState: {
+    user: null,
+  },
+  reducers: {
+    setUser(state, action) {
+      state.user = action.payload;
+    },
+    logout(state) {
+      state.user = null;
+    },
+  },
+});
+
+export const { setUser, logout } = authSlice.actions;
+export default authSlice.reducer;

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,7 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit';
+import authReducer from './authSlice';
 
 export default configureStore({
   reducer: {
-    // add reducers here
+    auth: authReducer,
   }
 });


### PR DESCRIPTION
## Summary
- dispatch user data to Redux after successful admin registration

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_b_684ecff0a7cc83259b2960a18ac42617