### PR TITLE
Fix server DB import

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const http = require('http');
 const app = require('./src/app');
-const connectDb = require('./src/db/connection');
+const { connect: connectDb } = require('./src/db/connection');
 const { connectRedis } = require('./src/db/redis');
 const { initSocket } = require('./src/sockets');
 


### PR DESCRIPTION
## Summary
- fix MongoDB connection import in backend `server.js`

## Testing
- `npm run test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `MONGO_URI=mongodb://localhost:27017/test node server.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_b_684ed94a5914832585e5f2266a6202c8