### PR TITLE
Improve redis config

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,6 @@
 PORT=3000
 MONGO_URI=mongodb://localhost:27017/mydb
+REDIS_URL=redis://localhost:6379
+# Optional Redis credentials
+REDIS_USERNAME=default
+REDIS_PASSWORD=yourpassword

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Testing Support Desk
+
+This repository contains a simple Node.js support desk application with a frontend and backend. The backend uses MongoDB and Redis.
+
+## Setup
+
+1. Install dependencies (requires npm):
+   ```bash
+   npm install
+   ```
+
+2. Copy `.env` and update the values:
+   ```env
+   PORT=3000
+   MONGO_URI=mongodb://localhost:27017/mydb
+   REDIS_URL=redis://localhost:6379
+   # Optional credentials if your Redis instance requires authentication
+   REDIS_USERNAME=default
+   REDIS_PASSWORD=yourpassword
+   ```
+
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+The server expects a running MongoDB instance and, if Redis requires a password, the credentials must be supplied through the environment variables shown above.

--- a/backend/src/db/redis.js
+++ b/backend/src/db/redis.js
@@ -1,7 +1,17 @@
 const { createClient } = require('redis');
 
 const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
-const redisClient = createClient({ url: redisUrl });
+const redisOptions = { url: redisUrl };
+
+if (process.env.REDIS_USERNAME) {
+  redisOptions.username = process.env.REDIS_USERNAME;
+}
+
+if (process.env.REDIS_PASSWORD) {
+  redisOptions.password = process.env.REDIS_PASSWORD;
+}
+
+const redisClient = createClient(redisOptions);
 
 redisClient.on('error', (err) => {
   console.error('Redis Client Error', err);

--- a/backend/src/jobs/ticketQueue.js
+++ b/backend/src/jobs/ticketQueue.js
@@ -1,7 +1,18 @@
 const { Queue, Worker } = require('bullmq');
 const IORedis = require('ioredis');
 
-const connection = new IORedis(process.env.REDIS_URL || 'redis://localhost:6379');
+const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+const redisOptions = { url: redisUrl };
+
+if (process.env.REDIS_USERNAME) {
+  redisOptions.username = process.env.REDIS_USERNAME;
+}
+
+if (process.env.REDIS_PASSWORD) {
+  redisOptions.password = process.env.REDIS_PASSWORD;
+}
+
+const connection = new IORedis(redisOptions);
 
 const ticketQueue = new Queue('ticketQueue', { connection });
 

--- a/backend/src/sockets/index.js
+++ b/backend/src/sockets/index.js
@@ -18,7 +18,17 @@ function initSocket(server) {
   });
 
   const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
-  const pubClient = createClient({ url: redisUrl });
+  const redisOptions = { url: redisUrl };
+
+  if (process.env.REDIS_USERNAME) {
+    redisOptions.username = process.env.REDIS_USERNAME;
+  }
+
+  if (process.env.REDIS_PASSWORD) {
+    redisOptions.password = process.env.REDIS_PASSWORD;
+  }
+
+  const pubClient = createClient(redisOptions);
   const subClient = pubClient.duplicate();
 
   Promise.all([pubClient.connect(), subClient.connect()])


### PR DESCRIPTION
## Summary
- support optional Redis username/password in backend
- update queue and socket adapters
- document env vars in README

## Testing
- `npm run dev` *(fails: nodemon not found)*

------
https://chatgpt.com/codex/tasks/task_b_684edd000ff483259c70b512559c6661