### PR TITLE
Add login and registration forms

### DIFF
--- a/frontend/src/components/Auth/Register.jsx
+++ b/frontend/src/components/Auth/Register.jsx
@@ -13,9 +13,10 @@ const Register = () => {
     workEmail: '',
     company: '',
     phone: '',
+    password: '',
   });
   const [error, setError] = useState(null);
-  const { firstName, lastName, workEmail, company, phone } = formData;
+  const { firstName, lastName, workEmail, company, phone, password } = formData;
 
   const onChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -31,6 +32,7 @@ const Register = () => {
         email: workEmail,
         company,
         phone,
+        password,
       });
       dispatch(setUser(user));
       navigate('/login');
@@ -98,9 +100,23 @@ const Register = () => {
             onChange={onChange}
           />
         </div>
+        <div className="mb-3">
+          <label className="form-label">Password</label>
+          <input
+            type="password"
+            className="form-control"
+            name="password"
+            value={password}
+            onChange={onChange}
+            required
+          />
+        </div>
         <button type="submit" className="btn btn-primary w-100">
           Register
         </button>
+        <div className="mt-3 text-center">
+          <a href="/login">Back to Login</a>
+        </div>
       </form>
     </div>
   );

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,5 +1,66 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { login } from '../services/authService';
+import { setUser } from '../store/authSlice';
 
-const Login = () => <div className="p-4">Login</div>;
+const Login = () => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const [formData, setFormData] = useState({ email: '', password: '' });
+  const [error, setError] = useState(null);
+  const { email, password } = formData;
+
+  const onChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const user = await login({ email, password });
+      dispatch(setUser(user));
+      navigate('/dashboard');
+    } catch (err) {
+      setError(err.response?.data?.message || 'Login failed');
+    }
+  };
+
+  return (
+    <div className="container mt-5" style={{ maxWidth: '400px' }}>
+      <h2 className="mb-4">Login</h2>
+      {error && <div className="alert alert-danger">{error}</div>}
+      <form onSubmit={onSubmit}>
+        <div className="mb-3">
+          <label className="form-label">Email</label>
+          <input
+            type="email"
+            className="form-control"
+            name="email"
+            value={email}
+            onChange={onChange}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Password</label>
+          <input
+            type="password"
+            className="form-control"
+            name="password"
+            value={password}
+            onChange={onChange}
+            required
+          />
+        </div>
+        <button type="submit" className="btn btn-primary w-100">Login</button>
+      </form>
+      <div className="mt-3 text-center">
+        <Link to="/register">Register</Link>
+      </div>
+    </div>
+  );
+};
 
 export default Login;

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -7,4 +7,9 @@ export const registerAdmin = async (data) => {
   return response.data;
 };
 
-export default { registerAdmin };
+export const login = async (data) => {
+  const response = await axios.post('/api/login', data);
+  return response.data;
+};
+
+export default { registerAdmin, login };


### PR DESCRIPTION
## Summary
- flesh out `Login` page with form and register link
- expand admin `Register` component with password field and link back to login
- add login API helper

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ee9ecf15c8325a26921244c54597f