### PR TITLE
Add login endpoint and fix auth service paths

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -5,6 +5,7 @@ const pingRoutes = require('./routes/pingRoutes');
 const userRoutes = require('./routes/userRoutes');
 const companyRoutes = require('./routes/companyRoutes');
 const kbRoutes = require('./routes/kbRoutes');
+const authRoutes = require('./routes/authRoutes');
 const errorHandler = require('./middleware/errorHandler');
 
 const app = express();
@@ -15,6 +16,7 @@ app.use(express.json());
 // Routes
 app.use('/api/v2', pingRoutes);
 app.use('/api/v2/register', userRoutes);
+app.use('/api/v2/auth', authRoutes);
 app.use('/api/v2', companyRoutes);
 app.use('/api/v2/kb', kbRoutes);
 

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,0 +1,24 @@
+const User = require('../models/User');
+const asyncHandler = require('../utils/asyncHandler');
+const apiResponse = require('../utils/apiResponse');
+const apiError = require('../utils/apiError');
+const { createToken } = require('../services/tokenService');
+const { comparePassword } = require('../services/passwordService');
+
+const login = asyncHandler(async (req, res) => {
+  const { email, password } = req.body;
+  const normalizedEmail = email.toLowerCase();
+  const user = await User.findOne({ email: normalizedEmail });
+  if (!user) {
+    throw new apiError(401, 'Invalid credentials');
+  }
+  if (!comparePassword(password, user.password)) {
+    throw new apiError(401, 'Invalid credentials');
+  }
+  const token = createToken({ id: user._id, role: user.role });
+  return res
+    .status(200)
+    .json(new apiResponse(200, { user, token }, 'Login successful'));
+});
+
+module.exports = { login };

--- a/backend/src/controllers/registerController.js
+++ b/backend/src/controllers/registerController.js
@@ -3,9 +3,10 @@ const asyncHandler = require('../utils/asyncHandler');
 const apiResponse = require('../utils/apiResponse');
 const apiError = require('../utils/apiError');
 const { createToken } = require('../services/tokenService');
+const { hashPassword } = require('../services/passwordService');
 
 const registerAdmin = asyncHandler(async (req, res) => {
-  const { firstName, lastName, email, company, phone } = req.body;
+  const { firstName, lastName, email, company, phone, password } = req.body;
   const normalizedEmail = email.toLowerCase();
 
   const existing = await User.aggregate([
@@ -24,6 +25,7 @@ const registerAdmin = asyncHandler(async (req, res) => {
     company,
     phone,
     email: normalizedEmail,
+    password: hashPassword(password),
   });
 
   await newUser.save();

--- a/backend/src/models/User.js
+++ b/backend/src/models/User.js
@@ -10,6 +10,7 @@ const UserSchema = new mongoose.Schema(
     },
     // common fields
     email: { type: String, required: true },
+    password: { type: String, required: true },
 
     // Admin specific
     firstName: String,

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { login } = require('../controllers/authController');
+
+const router = express.Router();
+
+router.post('/login', login);
+
+module.exports = router;

--- a/backend/src/services/passwordService.js
+++ b/backend/src/services/passwordService.js
@@ -1,0 +1,11 @@
+const crypto = require('crypto');
+
+function hashPassword(password) {
+  return crypto.createHash('sha256').update(password).digest('hex');
+}
+
+function comparePassword(password, hash) {
+  return hashPassword(password) === hash;
+}
+
+module.exports = { hashPassword, comparePassword };

--- a/frontend/src/components/Auth/Register.jsx
+++ b/frontend/src/components/Auth/Register.jsx
@@ -13,9 +13,10 @@ const Register = () => {
     workEmail: '',
     company: '',
     phone: '',
+    password: '',
   });
   const [error, setError] = useState(null);
-  const { firstName, lastName, workEmail, company, phone } = formData;
+  const { firstName, lastName, workEmail, company, phone, password } = formData;
 
   const onChange = (e) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -31,6 +32,7 @@ const Register = () => {
         email: workEmail,
         company,
         phone,
+        password,
       });
       dispatch(setUser(user));
       navigate('/login');
@@ -98,9 +100,23 @@ const Register = () => {
             onChange={onChange}
           />
         </div>
+        <div className="mb-3">
+          <label className="form-label">Password</label>
+          <input
+            type="password"
+            className="form-control"
+            name="password"
+            value={password}
+            onChange={onChange}
+            required
+          />
+        </div>
         <button type="submit" className="btn btn-primary w-100">
           Register
         </button>
+        <div className="mt-3 text-center">
+          <a href="/login">Back to Login</a>
+        </div>
       </form>
     </div>
   );

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,5 +1,66 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { login } from '../services/authService';
+import { setUser } from '../store/authSlice';
 
-const Login = () => <div className="p-4">Login</div>;
+const Login = () => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const [formData, setFormData] = useState({ email: '', password: '' });
+  const [error, setError] = useState(null);
+  const { email, password } = formData;
+
+  const onChange = (e) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const user = await login({ email, password });
+      dispatch(setUser(user));
+      navigate('/dashboard');
+    } catch (err) {
+      setError(err.response?.data?.message || 'Login failed');
+    }
+  };
+
+  return (
+    <div className="container mt-5" style={{ maxWidth: '400px' }}>
+      <h2 className="mb-4">Login</h2>
+      {error && <div className="alert alert-danger">{error}</div>}
+      <form onSubmit={onSubmit}>
+        <div className="mb-3">
+          <label className="form-label">Email</label>
+          <input
+            type="email"
+            className="form-control"
+            name="email"
+            value={email}
+            onChange={onChange}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">Password</label>
+          <input
+            type="password"
+            className="form-control"
+            name="password"
+            value={password}
+            onChange={onChange}
+            required
+          />
+        </div>
+        <button type="submit" className="btn btn-primary w-100">Login</button>
+      </form>
+      <div className="mt-3 text-center">
+        <Link to="/register">Register</Link>
+      </div>
+    </div>
+  );
+};
 
 export default Login;

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,10 +1,15 @@
 import axios from 'axios';
 
-const API_URL = '/api/register/';
+const API_URL = '/api/v2/register/';
 
 export const registerAdmin = async (data) => {
   const response = await axios.post(`${API_URL}admin`, data);
   return response.data;
 };
 
-export default { registerAdmin };
+export const login = async (data) => {
+  const response = await axios.post('/api/v2/auth/login', data);
+  return response.data;
+};
+
+export default { registerAdmin, login };


### PR DESCRIPTION
## Summary
- store user passwords and hash them
- register admins with a password hash
- add API route/controller for login
- wire new `/api/v2/auth` routes into the app
- update frontend auth service to point at new endpoints

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` in `frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ee9ecf15c8325a26921244c54597f