### PR TITLE
Fix instructions for running frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Node dependencies
+node_modules/
+backend/node_modules/
+frontend/node_modules/
+
+# Build outputs
+frontend/dist/
+
+# Environment variables
+.env
+frontend/.env
+
+# Misc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -19,9 +19,21 @@ This repository contains a simple Node.js support desk application with a fronte
    REDIS_PASSWORD=yourpassword
    ```
 
-3. Start the development server:
+3. Start the backend development server:
    ```bash
    npm run dev
    ```
+
+4. From the `frontend` directory install dependencies and run the React dev server:
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+
+   The frontend will be available at <http://localhost:5173>.
+
+   Environment variables are not required for the frontend by default, so the
+   `.env` file has been removed to avoid confusion.
 
 The server expects a running MongoDB instance and, if Redis requires a password, the credentials must be supplied through the environment variables shown above.

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,0 @@
-VITE_API_URL=http://localhost:5000


### PR DESCRIPTION
## Summary
- delete the unused frontend `.env`
- add a repository `.gitignore`
- document how to run the frontend in the README

## Testing
- `npm run test --if-present` *(fails: Unknown env config; network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_684fa77bb64c83259d6b09bc607b5250