### PR TITLE
Add user check to show register on first run

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 
 const pingRoutes = require('./routes/pingRoutes');
 const userRoutes = require('./routes/userRoutes');
+const userCheckRoutes = require('./routes/userCheckRoutes');
 const companyRoutes = require('./routes/companyRoutes');
 const kbRoutes = require('./routes/kbRoutes');
 const authRoutes = require('./routes/authRoutes');
@@ -16,6 +17,7 @@ app.use(express.json());
 // Routes
 app.use('/api/v2', pingRoutes);
 app.use('/api/v2/register', userRoutes);
+app.use('/api/v2', userCheckRoutes);
 app.use('/api/v2/auth', authRoutes);
 app.use('/api/v2', companyRoutes);
 app.use('/api/v2/kb', kbRoutes);

--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -1,0 +1,14 @@
+const User = require('../models/User');
+const asyncHandler = require('../utils/asyncHandler');
+const apiResponse = require('../utils/apiResponse');
+
+const checkAnyUser = asyncHandler(async (req, res) => {
+  const count = await User.countDocuments();
+  return res
+    .status(200)
+    .json(new apiResponse(200, { exists: count > 0 }, 'User check successful'));
+});
+
+module.exports = {
+  checkAnyUser,
+};

--- a/backend/src/routes/userCheckRoutes.js
+++ b/backend/src/routes/userCheckRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const { checkAnyUser } = require('../controllers/userController');
+
+const router = express.Router();
+
+router.get('/users/exist', checkAnyUser);
+
+module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import Forums from './pages/Forums';
 import Analytics from './pages/Analytics';
 import AdminSettings from './pages/AdminSettings';
 import Login from './pages/Login';
+import Startup from './pages/Startup';
 
 const App = () => {
   return (
@@ -20,6 +21,7 @@ const App = () => {
       <Sidebar />
       <div className="container-fluid">
         <Routes>
+          <Route path="/" element={<Startup />} />
           <Route path="/register" element={<Register />} />
           <Route path="/login" element={<Login />} />
           <Route path="/dashboard" element={<Dashboard />} />

--- a/frontend/src/pages/Startup.jsx
+++ b/frontend/src/pages/Startup.jsx
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { checkUsersExist } from '../services/authService';
+
+const Startup = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function check() {
+      try {
+        const data = await checkUsersExist();
+        if (data.data && data.data.exists) {
+          navigate('/login');
+        } else {
+          navigate('/register');
+        }
+      } catch (err) {
+        // default to login on error
+        navigate('/login');
+      }
+    }
+    check();
+  }, [navigate]);
+
+  return null;
+};
+
+export default Startup;

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -12,4 +12,9 @@ export const login = async (data) => {
   return response.data;
 };
 
-export default { registerAdmin, login };
+export const checkUsersExist = async () => {
+  const response = await axios.get('/api/v2/users/exist');
+  return response.data;
+};
+
+export default { registerAdmin, login, checkUsersExist };


### PR DESCRIPTION
## Summary
- add endpoint to check if any users exist
- redirect to register page on first run via new Startup component
- expose new service helper for user existence

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684fab57fbe88325b2120f6238b68c79